### PR TITLE
Add Robinhood Chain mainnet

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -337,7 +337,7 @@ const BASE_CHAINS: ChainMetadata[] = [
   {
     id: 'robinhood',
     name: 'Robinhood Chain',
-    shortName: 'Robinhood',
+    shortName: 'Robinhood Chain',
     caip2: 'eip155:4663',
     chainId: 4663,
     isOrbitChain: true,

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -335,6 +335,28 @@ const BASE_CHAINS: ChainMetadata[] = [
     description: 'Polygon is a popular sidechain/commit-chain that uses Plasma and Proof-of-Stake. It offers fast and cheap transactions for Ethereum DApps.'
   },
   {
+    id: 'robinhood',
+    name: 'Robinhood Chain',
+    shortName: 'Robinhood',
+    caip2: 'eip155:4663',
+    chainId: 4663,
+    isOrbitChain: true,
+    orbitMetadata: {
+      parentChain: 'Ethereum',
+      deployerTeam: 'Robinhood',
+      status: 'Mainnet',
+      layer: 2,
+      category: 'defi'
+    },
+    colors: {
+      light: ['#1C180D', '#1C180D'],
+      dark: ['#FFFFFF', '#FFFFFF'],
+      darkTextOnBackground: false
+    },
+    logo: null,
+    description: 'Robinhood Chain is a permissionless, EVM-compatible Arbitrum Layer 2 built for onchain financial infrastructure and real-world assets.'
+  },
+  {
     id: 'bnb_chain',
     name: 'BNB Smart Chain',
     shortName: 'BNB Chain',


### PR DESCRIPTION
## Summary

- add Robinhood Chain mainnet to the OLI chain registry
- register its CAIP-2 identifier as `eip155:4663`
- identify it as an Arbitrum Layer 2 on Ethereum
- use `Robinhood Chain` consistently as both the full and short display name

## Why

Robinhood Chain mainnet is live, but it is not currently selectable in OLI's attestation and search interfaces. The automated Arbitrum Orbit feed currently contains Robinhood Chain Testnet (`46630`) only, so it does not add mainnet (`4663`) to `CHAINS`.

Robinhood's documentation confirms mainnet chain ID `4663`, Ethereum as its parent chain, ETH as its gas token, and Blockscout as its explorer:

- https://docs.robinhood.com/chain/connecting/
- https://robinhoodchain.blockscout.com/

## Impact

OLI contributors will be able to select Robinhood Chain and submit or search chain-scoped labels for Robinhood addresses. This PR only registers the chain; it does not assert ownership of Robinhood or submit address labels.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

The production build completed successfully. It emitted the repository's existing optional dependency warnings for MetaMask React Native storage and `pino-pretty`.
